### PR TITLE
Minor tweaks found when trying to use with digitalrebar

### DIFF
--- a/roles/opencontrail/templates/contrail-control.conf.j2
+++ b/roles/opencontrail/templates/contrail-control.conf.j2
@@ -1,6 +1,6 @@
 [DEFAULT]
 hostip={{ opencontrail_host_address }}
-hostname={{ ansible_hostname }}
+hostname={{ ansible_nodename }}
 
 [IFMAP]
 server_url=https://localhost:{{ opencontrail_master_ifmap_port if opencontrail_master_ifmap_port is defined else 8443 }}

--- a/roles/opencontrail/templates/contrail-vrouter-agent.conf.gateway.j2
+++ b/roles/opencontrail/templates/contrail-vrouter-agent.conf.gateway.j2
@@ -9,6 +9,9 @@ physical_interface={{ opencontrail_host_interface }}
 {% if opencontrail_host_gateway -%}
 gateway={{ opencontrail_host_gateway }}
 {% endif -%}
+{% if opencontrail_no_arp -%}
+subnet_hosts_resolvable=0
+{% endif -%}
 
 {% if opencontrail_public_subnet is defined %}
 [GATEWAY-0]

--- a/roles/opencontrail/templates/contrail-vrouter-agent.conf.node.j2
+++ b/roles/opencontrail/templates/contrail-vrouter-agent.conf.node.j2
@@ -8,6 +8,9 @@ physical_interface={{ opencontrail_host_interface }}
 {% if opencontrail_host_gateway -%}
 gateway={{ opencontrail_host_gateway }}
 {% endif -%}
+{% if opencontrail_no_arp -%}
+subnet_hosts_resolvable=0
+{% endif -%}
 
 [HYPERVISOR]
 type=kvm

--- a/roles/opencontrail/templates/kube-network.conf.j2
+++ b/roles/opencontrail/templates/kube-network.conf.j2
@@ -6,7 +6,7 @@ service-cluster-ip-range = {{ opencontrail_all_service_addresses }}
 
 [opencontrail]
 public-ip-range = {{ opencontrail_public_subnet }}
-{% if opencontrail_private_subnet is defined %}
+{% if opencontrail_private_subnet is defined and opencontrail_private_subnet != "" %}
 private-ip-range = {{ opencontrail_private_subnet }}
 {% endif %}
 cluster-service = {{ opencontrail_cluster_services_namespace }}/default

--- a/roles/opencontrail/vars/main.yml
+++ b/roles/opencontrail/vars/main.yml
@@ -14,3 +14,6 @@ opencontrail_host_kernel_devel: "{{ ansible_kernel | regex_replace('([0-9.]+)-([
 opencontrail_host_kernel_build_dir: "/tmp/.ansible/build/{{ opencontrail_host_kernel_tag }}"
 opencontrail_host_kernel_install_dir: "/tmp/.ansible/install/{{ opencontrail_host_kernel_tag }}"
 opencontrail_host_kernel_artifact_tar: "/tmp/.ansible/opencontrail-vrouter-{{ opencontrail_host_kernel_tag }}.tgz"
+
+# Allow the system to have a way to override arp discovery of vrouters
+opencontrail_no_arp: false

--- a/roles/opencontrail_provision/tasks/master.yml
+++ b/roles/opencontrail_provision/tasks/master.yml
@@ -78,5 +78,5 @@
   command: >
     docker run --net=host opencontrail/config:2.20 /usr/share/contrail-utils/provision_control.py
     --api_server_ip localhost --api_server_port 8082
-    --host_name "{{ ansible_hostname }}" --host_ip "{{ opencontrail_host_address }}"
+    --host_name "{{ ansible_nodename }}" --host_ip "{{ opencontrail_host_address }}"
     --router_asn 64512 --oper add

--- a/roles/opencontrail_provision/tasks/nodes.yml
+++ b/roles/opencontrail_provision/tasks/nodes.yml
@@ -3,6 +3,6 @@
   command: >
     docker run --net=host opencontrail/config:2.20 /usr/share/contrail-utils/provision_vrouter.py
     --api_server_ip localhost
-    --host_name "{{ ansible_hostname }}{% if hostvars[inventory_hostname]['ansible_domain'] != "" %}.{{ hostvars[inventory_hostname]['ansible_domain'] }}{% endif %}"
+    --host_name "{{ ansible_nodename }}"
     --host_ip "{{ opencontrail_host_address }}"
   delegate_to: "{{ groups['masters'][0] }}"


### PR DESCRIPTION
Add ability to toggle whether to use arp or not generally (but for google case).

Make sure the we only write out the open contrail private field if has a value in it.

Switch the ansible_hostname use to ansible_nodename to ensure that the places that use hostname
match what the node returns when running the hostname command.
